### PR TITLE
适配64位系统cpu信息

### DIFF
--- a/device.php
+++ b/device.php
@@ -33,7 +33,7 @@ if (($str = @file("/proc/cpuinfo")) !== false){
     @preg_match_all("/BogoMIPS\s{0,}\:+\s{0,}([\d\.]+)[\r\n]+/", $str, $bogomips);
     @preg_match_all("/Model\s{0,}\:+\s{0,}([\w\s\)\(\@.-]+)([\r\n]+)/s", $str, $pimodel);
 
-    if (false){
+    if (is_array($model[1]) && !empty($model[1])){
         $D['cpu']['count'] = sizeof($model[1]);
         $bogomips[1][0] = ' | Bogomips:'.$bogomips[1][0];
         if($D['cpu']['count'] == 1){
@@ -48,11 +48,12 @@ if (($str = @file("/proc/cpuinfo")) !== false){
         @preg_match_all("/CPU\(s\)\s{0,}\:+\s{0,}(\d+)([\r\n]+)/s", $str, $cpucnt);
         if (false !== is_array($model[1])) {
             $D['cpu']['count'] = $cpucnt[1][0];
+            $bogomips[1][0] = ' | Bogomips:'.$bogomips[1][0];
             if($D['cpu']['count'] == 1){
-                $D['cpu']['model'] = $model[1][0].' '.$bogomips[1][0];
+                $D['cpu']['model'] = $model[1][0].$bogomips[1][0];
             }
             else{
-                $D['cpu']['model'] = $model[1][0].' '.$bogomips[1][0].' ×'.$D['cpu']['count'];
+                $D['cpu']['model'] = $model[1][0].$bogomips[1][0].' ×'.$D['cpu']['count'];
             }
         }
     }

--- a/device.php
+++ b/device.php
@@ -42,6 +42,21 @@ if (($str = @file("/proc/cpuinfo")) !== false){
         else{
             $D['cpu']['model'] = $model[1][0].$bogomips[1][0].' ×'.$D['cpu']['count'];
         }
+    } else {
+        if (($str = @shell_exec("lscpu")) !== false){
+            $str = implode("", $str);
+            @preg_match_all("/Model\s+name\s{0,}\:+\s{0,}([\w\s\)\(\@.-]+)([\r\n]+)/s", $str, $model);
+            @preg_match_all("/CPU\(s\)\s{0,}\:+\s{0,}(\d+)([\r\n]+)/s", $str, $cpucnt);
+            if (false !== is_array($model[1])) {
+                $D['cpu']['count'] = $cpucnt[1][0];
+                if($D['cpu']['count'] == 1){
+                    $D['cpu']['model'] = $model[1][0].$bogomips[1][0];
+                }
+                else{
+                    $D['cpu']['model'] = $model[1][0].$bogomips[1][0].' ×'.$D['cpu']['count'];
+                }
+            }
+        }
     }
 
     if (false !== is_array($pimodel[1])){

--- a/device.php
+++ b/device.php
@@ -33,7 +33,7 @@ if (($str = @file("/proc/cpuinfo")) !== false){
     @preg_match_all("/BogoMIPS\s{0,}\:+\s{0,}([\d\.]+)[\r\n]+/", $str, $bogomips);
     @preg_match_all("/Model\s{0,}\:+\s{0,}([\w\s\)\(\@.-]+)([\r\n]+)/s", $str, $pimodel);
 
-    if (false !== is_array($model[1])){
+    if (false){
         $D['cpu']['count'] = sizeof($model[1]);
         $bogomips[1][0] = ' | Bogomips:'.$bogomips[1][0];
         if($D['cpu']['count'] == 1){
@@ -43,18 +43,16 @@ if (($str = @file("/proc/cpuinfo")) !== false){
             $D['cpu']['model'] = $model[1][0].$bogomips[1][0].' ×'.$D['cpu']['count'];
         }
     } else {
-        if (($str = @shell_exec("lscpu")) !== false){
-            $str = implode("", $str);
-            @preg_match_all("/Model\s+name\s{0,}\:+\s{0,}([\w\s\)\(\@.-]+)([\r\n]+)/s", $str, $model);
-            @preg_match_all("/CPU\(s\)\s{0,}\:+\s{0,}(\d+)([\r\n]+)/s", $str, $cpucnt);
-            if (false !== is_array($model[1])) {
-                $D['cpu']['count'] = $cpucnt[1][0];
-                if($D['cpu']['count'] == 1){
-                    $D['cpu']['model'] = $model[1][0].$bogomips[1][0];
-                }
-                else{
-                    $D['cpu']['model'] = $model[1][0].$bogomips[1][0].' ×'.$D['cpu']['count'];
-                }
+        $str = shell_exec("lscpu");
+        @preg_match_all("/Model\s+name\s{0,}\:+\s{0,}([\w\s\)\(\@.-]+)([\r\n]+)/s", $str, $model);
+        @preg_match_all("/CPU\(s\)\s{0,}\:+\s{0,}(\d+)([\r\n]+)/s", $str, $cpucnt);
+        if (false !== is_array($model[1])) {
+            $D['cpu']['count'] = $cpucnt[1][0];
+            if($D['cpu']['count'] == 1){
+                $D['cpu']['model'] = $model[1][0].' '.$bogomips[1][0];
+            }
+            else{
+                $D['cpu']['model'] = $model[1][0].' '.$bogomips[1][0].' ×'.$D['cpu']['count'];
             }
         }
     }

--- a/index.php
+++ b/index.php
@@ -214,7 +214,7 @@ require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'device.php');
                                 </div>
                                 <div class="col-md-2 col-sm-2 col-xs-2" style="padding: 0;">
                                     <div style="height: 80px; margin-top: 10px;">
-                                        <div class="text-center" style="padding: 2px 0 2px 0; background-color: #CCCCCC;"><strong><span id="net-interface-<?php echo($i+1) ?>-name"><?php echo($D['net']['interfaces'][$i]['name']) ?></span></strong></div>
+                                        <div class="text-center" style="padding: 2px 0 2px 0; background-color: #CCCCCC; word-wrap: break-word;"><strong><span id="net-interface-<?php echo($i+1) ?>-name"><?php echo($D['net']['interfaces'][$i]['name']) ?></span></strong></div>
                                         <div class="text-center" style="padding: 10px 0 10px 0; background-color: #9BCEFD;"><span id="net-interface-<?php echo($i+1) ?>-total-in"><?php echo($D['net']['interfaces'][$i]['total_in']) ?></span><br /><small class="label">IN</small></div>
                                         <div class="text-center" style="padding: 10px 0 10px 0; background-color: #CDFD9F;"><span id="net-interface-<?php echo($i+1) ?>-total-out"><?php echo($D['net']['interfaces'][$i]['total_out']) ?></span><br /><small class="label">OUT</small></div>
                                     </div>


### PR DESCRIPTION
在64位系统上，`/proc/cpuinfo`中缺少`model name`，导致pi-dashboard无法获取cpu信息，如下

```
processor       : 0
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 2
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 3
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

Hardware        : BCM2835
Revision        : c03115
Serial          : 1000000010d65790
Model           : Raspberry Pi 4 Model B Rev 1.5
```

因此，当从`/proc/cpuinfo`获取不到cpu信息时，从`lscpu`命令获取。